### PR TITLE
feat: openapi

### DIFF
--- a/apps/web/app/api/[...route]/route.ts
+++ b/apps/web/app/api/[...route]/route.ts
@@ -149,6 +149,9 @@ const api = new OpenAPIHono()
       method: "get",
       path: "/accounts/:user_id/checkout",
       request: {
+        params: z.object({
+          user_id: z.string().openapi({ description: "TODO" })
+        }),
         query: z.object({
           plan: PricingPlanId.openapi({
             description: "TODO",
@@ -477,15 +480,14 @@ const api = new OpenAPIHono()
         const timestamp = Date.now().toString().slice(-6); // Last 6 digits of timestamp
         const baseName = providedName
           ? providedName
-              .toLowerCase()
-              .replace(/[^a-z0-9]/g, "-") // Replace non-alphanumeric with hyphens
-              .replace(/-+/g, "-") // Replace multiple hyphens with single
-              .replace(/^-|-$/g, "") // Remove leading/trailing hyphens
+            .toLowerCase()
+            .replace(/[^a-z0-9]/g, "-") // Replace non-alphanumeric with hyphens
+            .replace(/-+/g, "-") // Replace multiple hyphens with single
+            .replace(/^-|-$/g, "") // Remove leading/trailing hyphens
           : "image";
 
-        const fileName = `${baseName}-${timestamp}.${
-          convertToWebp ? "webp" : "jpg"
-        }`;
+        const fileName = `${baseName}-${timestamp}.${convertToWebp ? "webp" : "jpg"
+          }`;
 
         try {
           await r2.send(
@@ -860,9 +862,8 @@ const api = new OpenAPIHono()
         const r2 = createR2Client();
         const buffer = Buffer.from(await image.arrayBuffer());
         const timestamp = Date.now().toString().slice(-6);
-        const fileName = `${authorSlug}-${timestamp}.${
-          image.type.split("/")[1]
-        }`;
+        const fileName = `${authorSlug}-${timestamp}.${image.type.split("/")[1]
+          }`;
 
         await r2.send(
           new PutObjectCommand({

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "dependencies": {
         "@ai-sdk/openai": "^0.0.24",
+        "@hono/zod-openapi": "^0.18.4",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@supabase/ssr": "^0.5.0",
         "@types/inquirer": "^9.0.3",
@@ -283,6 +284,22 @@
         "supabase": "^1.61.2",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "apps/web/node_modules/@hono/zod-openapi": {
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-0.16.4.tgz",
+      "integrity": "sha512-mnF6GthBaKex0D5PsY/4lYNtkaGJNE38bjeUI//EUqq7Ee4TNm2su35IUiFH4HcmJp5fWYMLyOJOpjnkClzEGw==",
+      "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.1.0",
+        "@hono/zod-validator": "0.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "hono": ">=4.3.6",
+        "zod": "3.*"
       }
     },
     "apps/web/node_modules/@next/swc-darwin-arm64": {
@@ -3541,12 +3558,12 @@
       }
     },
     "node_modules/@hono/zod-openapi": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-0.16.4.tgz",
-      "integrity": "sha512-mnF6GthBaKex0D5PsY/4lYNtkaGJNE38bjeUI//EUqq7Ee4TNm2su35IUiFH4HcmJp5fWYMLyOJOpjnkClzEGw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-0.18.4.tgz",
+      "integrity": "sha512-6NHMHU96Hh32B1yDhb94Z4Z5/POsmEu2AXpWLWcBq9arskRnOMt2752yEoXoADV8WUAc7H1IkNaQHGj1ytXbYw==",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.1.0",
-        "@hono/zod-validator": "0.3.0"
+        "@hono/zod-validator": "^0.4.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -3554,6 +3571,15 @@
       "peerDependencies": {
         "hono": ">=4.3.6",
         "zod": "3.*"
+      }
+    },
+    "node_modules/@hono/zod-openapi/node_modules/@hono/zod-validator": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.4.2.tgz",
+      "integrity": "sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g==",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.19.1"
       }
     },
     "node_modules/@hono/zod-validator": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "@ai-sdk/openai": "^0.0.24",
+    "@hono/zod-openapi": "^0.18.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@supabase/ssr": "^0.5.0",
     "@types/inquirer": "^9.0.3",


### PR DESCRIPTION
This uses hono-openapi to reuse the existing zod schemas to generate an openapi spec.

There are lots of `TODO`s left, mostly descriptions that will show up in your spec and therefore docs.

For some reason this broke a component of yours, I haven't been able to figure out why but I also can't run this entirely due to lack of supabase db etc. I've been flying mostly blind.

It's not perfect, but a good foundation/inspiration to do the move properly.

Give it a go though:
```
npm run dev:web

// different terminal
npx @scalar/cli serve http://localhost:8082/api/v2/openapi.json
``` 

