### PR TITLE
fix: close stargazers anchor URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/jordienr/zenblog/stargazers>
+  <a href="https://github.com/jordienr/zenblog/stargazers">
     <img src="https://img.shields.io/github/stars/jordienr/zenblog?logo=github&style=for-the-badge&color=yellow" alt="Github Stars"></a>
   </a>
 </p>


### PR DESCRIPTION
## Summary
- close href quote for stargazers link in README

## Testing
- `npx prettier README.md -w`
- `npm test` *(fails: fetch failed / ECONNREFUSED)*
- `npx markdown-it README.md | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a72f1491788333966d62372cb6b55b