### PR TITLE
fix: Reset inputs after adding a category

### DIFF
--- a/apps/web/src/pages/blogs/[blogId]/categories.tsx
+++ b/apps/web/src/pages/blogs/[blogId]/categories.tsx
@@ -72,6 +72,8 @@ export function CreateCategoryDialog({
                 blog_id: blogId,
               });
               toast.success("Category created");
+              setName("");
+              setSlug("");
               setOpen(false);
             } catch (error) {
               toast.error("Failed to create category. Slugs must be unique.");


### PR DESCRIPTION
### Summary
Super super simple PR that resets inputs in "Create category" dialog after successful insert

### Issue
Fixes #25 