### PR TITLE
[codex] harden homepage auth proxy refresh

### DIFF
--- a/apps/web/src/utils/supabase/middleware.ts
+++ b/apps/web/src/utils/supabase/middleware.ts
@@ -8,53 +8,67 @@ export async function updateSession(request: NextRequest) {
     },
   });
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
+  try {
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) {
+            return request.cookies.get(name)?.value;
+          },
+          set(name: string, value: string, options: CookieOptions) {
+            request.cookies.set({
+              name,
+              value,
+              ...options,
+            });
+            response = NextResponse.next({
+              request: {
+                headers: request.headers,
+              },
+            });
+            response.cookies.set({
+              name,
+              value,
+              ...options,
+            });
+          },
+          remove(name: string, options: CookieOptions) {
+            request.cookies.set({
+              name,
+              value: "",
+              ...options,
+            });
+            response = NextResponse.next({
+              request: {
+                headers: request.headers,
+              },
+            });
+            response.cookies.set({
+              name,
+              value: "",
+              ...options,
+            });
+          },
         },
-        set(name: string, value: string, options: CookieOptions) {
-          request.cookies.set({
-            name,
-            value,
-            ...options,
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          });
-          response.cookies.set({
-            name,
-            value,
-            ...options,
-          });
-        },
-        remove(name: string, options: CookieOptions) {
-          request.cookies.set({
-            name,
-            value: "",
-            ...options,
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          });
-          response.cookies.set({
-            name,
-            value: "",
-            ...options,
-          });
-        },
+      }
+    );
+
+    await supabase.auth.getUser();
+
+    return response;
+  } catch (error) {
+    console.error("Supabase proxy session refresh failed", {
+      pathname: request.nextUrl.pathname,
+      error,
+    });
+
+    // Never take down public pages because auth refresh failed for one request.
+    return NextResponse.next({
+      request: {
+        headers: request.headers,
       },
-    }
-  );
-
-  await supabase.auth.getUser();
-
-  return response;
+    });
+  }
 }


### PR DESCRIPTION
## Summary

Harden the homepage auth proxy path so a Supabase session refresh failure does not take down public pages.

## What changed

- wrap the Supabase middleware session refresh in `try/catch`
- log the failing pathname for debugging
- fail open with `NextResponse.next()` when auth refresh throws

## Why

We saw reports that the homepage could fail for some users along with Vercel `MIDDLEWARE_INVOCATION_FAILED` errors. The proxy runs before the homepage renders, and previously any exception from the Supabase auth refresh path would bubble out of the edge function and fail the request.

This change keeps public pages available even when auth refresh fails for a specific request, cookie state, or transient upstream issue.

## Validation

- `npm run typecheck --workspace web`

## Notes

This does not fully explain the separate `SIGSEGV` signal on its own, but it removes the most obvious application-level way for the homepage to fail before rendering and should reduce user-visible outages caused by middleware exceptions.